### PR TITLE
Added missing dependencies

### DIFF
--- a/lib/PrepareTool.sh
+++ b/lib/PrepareTool.sh
@@ -2,13 +2,24 @@
 
 set -e
 
-if ! hash apt-get 2>/dev/null; then
-    whiptail --title "Orangepi Build System" --msgbox "This scripts requires a Debian based distrbution. If you not use Debian/Ubunut, pls install:[ bsdtar mtools u-boot-tools pv bc sunxi-tools gcc automake make qemu dosfstools ]"
-    exit 1
-fi
-
-apt-get -y --no-install-recommends --fix-missing install \
+dependencies="\
+    whiptail \
+    curl git rsync unzip \
+    cpio figlet device-tree-compiler parted \
     bsdtar mtools u-boot-tools pv bc \
     gcc automake make \
     lib32z1 lib32z1-dev qemu-user-static \
-    dosfstools figlet device-tree-compiler debootstrap
+    dosfstools figlet device-tree-compiler debootstrap \
+"
+
+if ! hash apt-get 2>/dev/null; then
+    err_msg="This scripts requires a Debian based distrbution. If you not use Debian/Ubuntu, pls install:[ $dependencies ]"
+    if ! hash whiptail 2>/dev/null; then
+        echo "ERROR: $err_msg" >&2
+    else
+        whiptail --title "Orangepi Build System" --msgbox "$err_msg" 15 60 0
+    fi
+    exit 1
+fi
+
+apt-get -y --no-install-recommends --fix-missing install $dependencies


### PR DESCRIPTION
I have successfully built the OrangePi One image using OrangePi_Build system in a Docker container only after I installed some extra dependencies (`git whiptail sudo curl unzip figlet device-tree-compiler parted rsync`), so I think it is valuable to add them to the PrepareTool.sh script to ensure that everyone is on the same page.

P.S. To build the image inside a container, you need to run the container with `--privileged` flag, install the missing dependencies and set `/etc/timezone`:

```
$ docker run -it --rm "$(pwd):/mnt" --privileged ubuntu:18.04 bash
root@xxx:/# apt update
root@xxx:/# apt install git make whiptail sudo curl unzip figlet device-tree-compiler parted rsync
root@xxx:/# echo Europe/Kiev > /etc/timezone
root@xxx:/# cd /mnt/OrangePi_Build
```