### PR TITLE
Fixed missing parameters of whiptail msgbox.

### DIFF
--- a/lib/general.sh
+++ b/lib/general.sh
@@ -29,7 +29,7 @@ EOF
 prepare_tools()
 {
 	if ! hash apt-get 2>/dev/null; then
-		whiptail --title "Orangepi Build System" --msgbox "This scripts requires a Debian based distrbution. If you not use Debian/Ubunut, pls install:[ bsdtar mtools u-boot-tools pv bc sunxi-tools gcc automake make curl qemu dosfstools ]"
+		whiptail --title "Orangepi Build System" --msgbox "This scripts requires a Debian based distrbution. If you not use Debian/Ubunut, pls install:[ bsdtar mtools u-boot-tools pv bc sunxi-tools gcc automake make curl qemu dosfstools ]" 10 60
 	        exit 1
 	fi
 


### PR DESCRIPTION
Fixed usage of `whiptail --msgbox`: missing parameters. It didn't show the intended warning message.